### PR TITLE
recipes-initscripts/cml-boot: Migrate to fragments

### DIFF
--- a/recipes-initscripts/cml-boot/cml-boot_%.bbappend
+++ b/recipes-initscripts/cml-boot/cml-boot_%.bbappend
@@ -1,5 +1,2 @@
 ## Remove redirection of console output for beaglev-fire
-do_install:prepend:beaglev-fire() {
-	sed -i '/exec > \/dev\/$LOGTTY*/c\#exec > \/dev\/$LOGTTY' ${WORKDIR}/cml-boot-script.stub
-	sed -i '/exec 2>&1*/c\#exec 2>&1' ${WORKDIR}/cml-boot-script.stub
-}
+SRC_URI:remove:beaglev-fire = "file://15-redirect-logtty.fragment"


### PR DESCRIPTION
Remove the logtty redirect fragment.


[michael.weiss: applied corresponding change from meta-gyroidos-nxp]